### PR TITLE
setup.cfg classifiers are explicit in python versions supported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,8 @@ author = %%author%%
 author_email = %%email%%
 home_page = http://github.com/0k/%%name%%
 classifier =
-    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 3
     Topic :: Software Development :: Libraries :: Python Modules
     Development Status :: 3 - Alpha
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
!minor

These classifiers are regarding which versions of python are supported, making support for Python 3 explicit.

It's these classifiers that helps [this tool](https://github.com/brettcannon/caniusepython3) (`caniusepython3`) understand this project won't be a blocker to Python 3 migration.

That tool was discovered via [this article](https://tech.yplanapp.com/2016/08/24/upgrading-to-python-3-with-zero-downtime/).